### PR TITLE
Add rubocop and rspec to circle ci github checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,37 @@
 version: 2.1
+
+aliases:
+  - &install_dependencies
+    name: install dependecies
+    command: |
+      gem install bundler -v 2.2.11
+      bundle install
+
 jobs:
-  build:
+  lint:
     docker:
       - image: ruby:2.7.0
     steps:
       - checkout
+      - run: *install_dependencies
       - run:
-          name: Run the default task
-          command: |
-            gem install bundler -v 2.2.11
-            bundle install
-            bundle exec rake
+          name: Run rubocop
+          command: bundle exec rubocop --fail-fast .
+  rspec:
+    docker:
+      - image: ruby:2.7.0
+    steps:
+      - checkout
+      - run: *install_dependencies
+      - run:
+          name: Run rspec tests
+          command: bundle exec rspec spec/
+
+workflows:
+  version: 2
+  test_all:
+    jobs:
+      - lint
+      - rspec:
+          requires:
+            - lint

--- a/spec/obs_github_deployments_spec.rb
+++ b/spec/obs_github_deployments_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe ObsGithubDeployments do
   it "has a version number" do
     expect(ObsGithubDeployments::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
The checks are getting triggered once the PR is merged, unfortunately not in the initial PR itself. 