### PR TITLE
Introduce version as first CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 [![openSUSE](https://circleci.com/gh/openSUSE/obs_github_deployments.svg?style=svg)](https://app.circleci.com/pipelines/github/openSUSE/obs_github_deployments)
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/obs_github_deployments`. To experiment with that code, run `bin/console` for an interactive prompt.
+CLI tool and wrapper to interact with GitHub deployments, used by the Ansible setup for the deployments of the [Open Build Service](https://openbuildservice.org) reference instance.
 
-TODO: Delete this and the text above, and describe your gem
+With ObsGithubDeploymnets you can:
+- Get information about the last deployments (history).
+- Get the status of the last deployment.
+- Lock a deployment.
+- Unlock a deployment.
 
 ## Installation
 
@@ -24,7 +28,13 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+From development environment:
+
+To know the version of this gem:
+
+```
+ruby obs_github_deployments -v
+```
 
 ## Development
 
@@ -34,4 +44,4 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/obs_github_deployments.
+Bug reports and pull requests are welcome on GitHub at https://github.com/openSUSE/obs_github_deployments.

--- a/bin/obs_github_deployments
+++ b/bin/obs_github_deployments
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), "..", "lib")
+
+require "obs_github_deployments"
+require "dry/cli"
+
+Dry::CLI.new(ObsGithubDeployments::CLI::Commands).call

--- a/lib/obs_github_deployments.rb
+++ b/lib/obs_github_deployments.rb
@@ -2,6 +2,7 @@
 
 require "zeitwerk"
 loader = Zeitwerk::Loader.for_gem
+loader.inflector.inflect("cli" => "CLI")
 loader.setup
 
 module ObsGithubDeployments

--- a/lib/obs_github_deployments/cli/commands.rb
+++ b/lib/obs_github_deployments/cli/commands.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ObsGithubDeployments
+  module CLI
+    module Commands
+      extend Dry::CLI::Registry
+      # register the commands and its command line
+      register "version", Version, aliases: ["v", "-v", "--version"]
+    end
+  end
+end

--- a/lib/obs_github_deployments/cli/commands/version.rb
+++ b/lib/obs_github_deployments/cli/commands/version.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ObsGithubDeployments
+  module CLI
+    module Commands
+      # Version command
+      class Version < Dry::CLI::Command
+        desc "Print obs_gihub_deployments gem version"
+        def call(*)
+          puts ObsGithubDeployments::VERSION
+        end
+      end
+    end
+  end
+end

--- a/obs_github_deployments.gemspec
+++ b/obs_github_deployments.gemspec
@@ -33,7 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 1.7"
-  spec.add_dependency "zeitwerk"
+  spec.add_dependency "dry-cli", "~> 0.6"
+  spec.add_dependency "zeitwerk", "~> 2.4"
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
First steps in the implementation of the gem:

- Start filling README.md.
- Introduce a simple CLI command: `version`. Use 'dry-cli' gem to implement it.

To test this in development environment you can run:
- `bundle install`
- `ruby bin/obs_github_deployments -h` to see the commands available and its descriptions
- `ruby bin/obs_github_deployments -v` to get the current version of the gem

**Edit:** Code adapted to use `zeitwerk`, so no file `require` are needed.