### PR TITLE
Add *.gem file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /spec/reports/
 /tmp/
 Gemfile.lock
+*.gem
 
 # rspec failure tracking
 .rspec_status


### PR DESCRIPTION
During development time, we can build the `*.gem` for testing purposes. We don't want to add it to the repository at that time nor when the gem is ready to be published.