### PR TITLE
Load environment variables and add instructions in README.md

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+# GitHub credentials to access the repository repository where you are going to track the deployments.
+export GITHUB_TOKEN=GITHUB_TOKEN
+export GITHUB_REPOSITORY=GITHUB_REPOSITORY
+export GITHUB_BRANCH=GITHUB_BRANCH

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /tmp/
 Gemfile.lock
 *.gem
+.env
 
 # rspec failure tracking
 .rspec_status

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Or install it yourself as:
 
 ## Usage
 
+Require the gem whenever you need it:
+
+```ruby
+    require 'obs_github_deployments'
+```
+
+Set the environment variables needed to make GitHub API calls and access the repository where you are going to track the deployments. Do so in the `.env` file taking `.env.sample` as example.
+
+You can obtain the token in GitHub: `Settings > Developer Settings > Personal access tokens`.
+It is enough to enable `repo:status` and `repo_deployment` scopes.
+
 From development environment:
 
 To know the version of this gem:


### PR DESCRIPTION
The credentials to make calls to the GitHub API and the repository, where the deployments are tracked, are set as environment variables.