### PR TITLE
Create a rake task to operate on test deployments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,10 @@ AllCops:
   TargetRubyVersion: 2.4
   NewCops: enable
 
+Metrics/BlockLength:
+  Exclude:
+    - 'tasks/*'
+
 Style/Documentation:
   Enabled: false
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 require "rubocop/rake_task"
+Dir["tasks/*.rake"].each { |t| load t }
 
 RuboCop::RakeTask.new
 

--- a/obs_github_deployments.gemspec
+++ b/obs_github_deployments.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 1.7"
   spec.add_dependency "dry-cli", "~> 0.6"
+  spec.add_dependency "octokit", "~> 4.20"
   spec.add_dependency "zeitwerk", "~> 2.4"
 
   # For more information and examples about making a new gem, checkout our

--- a/tasks/deployments.rake
+++ b/tasks/deployments.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "octokit"
+
+DEFAULT_STATE = "pending"
+DEFAULT_BRANCH = "main"
+
+namespace :deployments do
+  task :config do
+    @repo_name = ENV["GITHUB_TEST_REPOSITORY"]
+    @access_token = ENV["GITHUB_TEST_TOKEN"]
+    @client = Octokit::Client.new(access_token: @access_token)
+  end
+
+  desc "Create a deployment on a specific repository"
+  task create_deployment: :config do
+    @client.create_deployment(@repo_name, DEFAULT_BRANCH)
+  end
+
+  desc "Change the state of a specific deployment"
+  task :change_state, [:state] => [:config] do |_, args|
+    begin
+      deployment_state = args.with_defaults(state: DEFAULT_STATE)
+      options = { accept: "application/vnd.github.flash-preview+json" }
+      deployment = @client.deployments(@repo_name).first
+      puts @client.create_deployment_status(deployment.url, deployment_state[:state], options).state
+    rescue Octokit::InvalidRepository
+      puts "ERROR: No repository name specified. Please set the GITHUB_TEST_REPOSITORY environment variable."
+    end
+  end
+
+  desc "Checks the state of a specific deployment"
+  task check_state: :config do
+    begin
+      deployment = @client.deployments(@repo_name).first
+      puts @client.deployment_statuses(deployment.url).first.state
+    rescue Octokit::InvalidRepository
+      puts "ERROR: No repository name specified. Please set the GITHUB_TEST_REPOSITORY environment variable."
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces three rake tasks to help dealing with test deployments.

When creating VCR cassettes, you need to have a testing repository in a specific
deployment state. With this tasks you can:

- Create a new deployment
- Change the last deployment status
- Check the last deployment status