### PR TITLE
Implement the is-locked command

### DIFF
--- a/bin/obs_github_deployments
+++ b/bin/obs_github_deployments
@@ -5,5 +5,10 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), "..", "lib")
 
 require "obs_github_deployments"
 require "dry/cli"
+require "json"
 
-Dry::CLI.new(ObsGithubDeployments::CLI::Commands).call
+begin
+  Dry::CLI.new(ObsGithubDeployments::CLI::Commands).call
+rescue StandardError => e
+  abort({ status: "error", reason: e.message }.to_json)
+end

--- a/lib/obs_github_deployments/cli/commands.rb
+++ b/lib/obs_github_deployments/cli/commands.rb
@@ -5,6 +5,7 @@ module ObsGithubDeployments
     module Commands
       extend Dry::CLI::Registry
       # register the commands and its command line
+      register "check-lock", CheckLock, aliases: ["c", "-c"]
       register "version", Version, aliases: ["v", "-v", "--version"]
       register "set-lock", SetLock, aliases: ["s", "-s", "--set-lock"]
     end

--- a/lib/obs_github_deployments/cli/commands/check_lock.rb
+++ b/lib/obs_github_deployments/cli/commands/check_lock.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ObsGithubDeployments
+  module CLI
+    module Commands
+      class CheckLock < ObsCommand
+        desc "Checks if the deployment is locked"
+
+        option :repository,
+               default: ENV["GITHUB_REPOSITORY"],
+               desc: "The GitHub repository to check if locked"
+        option :token,
+               default: ENV["GITHUB_TOKEN"],
+               desc: "GitHub authentication token used to authenticate against the API"
+
+        def call(**options)
+          raise_error("You need to provide a repository name") unless options[:repository]
+          raise_error("You need to provide a token in order to authenticate") unless options[:token]
+
+          response = client(repository: options[:repository], token: options[:token]).locked?
+          puts status_response(status: response ? "locked" : "unlocked")
+        end
+
+        private
+
+        def client(repository:, token:)
+          ObsGithubDeployments::Deployment.new(repository: repository,
+                                               access_token: token)
+        end
+      end
+    end
+  end
+end

--- a/lib/obs_github_deployments/cli/commands/obs_command.rb
+++ b/lib/obs_github_deployments/cli/commands/obs_command.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ObsGithubDeployments
+  module CLI
+    module Commands
+      class ObsCommand < Dry::CLI::Command
+        protected
+
+        def status_response(status:, reason: "")
+          { status: status, reason: reason }.to_json
+        end
+
+        def raise_error(message)
+          raise(Dry::CLI::Error, message)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This command checks if a repo has its deployments locked or not.
The parameters are specified as command line arguments.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>