### PR TITLE
Remove redundant exit call

### DIFF
--- a/lib/obs_github_deployments/cli/commands/set_lock.rb
+++ b/lib/obs_github_deployments/cli/commands/set_lock.rb
@@ -28,7 +28,6 @@ module ObsGithubDeployments
                  ObsGithubDeployments::Deployment::NoReasonGivenError => e
             abort(e.message)
           end
-          exit(0)
         end
       end
     end


### PR DESCRIPTION
The call to exit is not needed, since the method called in
the begin block returns true anyway on a successful run.