### PR TITLE
Provide a shorter executable alias

### DIFF
--- a/bin/ogd
+++ b/bin/ogd
@@ -1,0 +1,1 @@
+obs_github_deployments


### PR DESCRIPTION
The alias is `ogd`.

This is just a symlink to the `obs_github_deployments` executable