### PR TITLE
Add pry-byebug as a development dependency

### DIFF
--- a/obs_github_deployments.gemspec
+++ b/obs_github_deployments.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Abin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "pry-byebug", "~> 3"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 1.7"


### PR DESCRIPTION
I don't know for you, but I find it hard to live without pry and byebug.