### PR TITLE
Do not verify if CI status checks passed on the master branch

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
 
 Metrics/BlockLength:

--- a/lib/obs_github_deployments/deployment.rb
+++ b/lib/obs_github_deployments/deployment.rb
@@ -72,7 +72,10 @@ module ObsGithubDeployments
     end
 
     def create
-      options = { auto_merge: false }
+      # auto_merge: Do not merge the default branch into the requested deployment branch if necessary
+      # required_contexts: Do not verify if CI status checks passed on the master branch.  This allows us to create a
+      #                    deployment, even if somehow codecov failed or we have a flickering spec.
+      options = { auto_merge: false, required_contexts: [] }
 
       @client.create_deployment(@repository, @ref, options)
     end

--- a/obs_github_deployments.gemspec
+++ b/obs_github_deployments.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
                         used by the Ansible setup for the deployments of the
                         Open Build Service reference instance."
   spec.homepage      = "https://github.com/openSUSE/obs_github_deployments"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 

--- a/tasks/deployments.rake
+++ b/tasks/deployments.rake
@@ -20,23 +20,19 @@ namespace :deployments do
 
   desc "Change the state of a specific deployment"
   task :change_state, [:state] => [:config] do |_, args|
-    begin
-      deployment_state = args.with_defaults(state: DEFAULT_STATE)
-      options = { accept: "application/vnd.github.flash-preview+json" }
-      deployment = @client.deployments(@repo_name).first
-      puts @client.create_deployment_status(deployment.url, deployment_state[:state], options).state
-    rescue Octokit::InvalidRepository
-      puts "ERROR: No repository name specified. Please set the GITHUB_TEST_REPOSITORY environment variable."
-    end
+    deployment_state = args.with_defaults(state: DEFAULT_STATE)
+    options = { accept: "application/vnd.github.flash-preview+json" }
+    deployment = @client.deployments(@repo_name).first
+    puts @client.create_deployment_status(deployment.url, deployment_state[:state], options).state
+  rescue Octokit::InvalidRepository
+    puts "ERROR: No repository name specified. Please set the GITHUB_TEST_REPOSITORY environment variable."
   end
 
   desc "Checks the state of a specific deployment"
   task check_state: :config do
-    begin
-      deployment = @client.deployments(@repo_name).first
-      puts @client.deployment_statuses(deployment.url).first.state
-    rescue Octokit::InvalidRepository
-      puts "ERROR: No repository name specified. Please set the GITHUB_TEST_REPOSITORY environment variable."
-    end
+    deployment = @client.deployments(@repo_name).first
+    puts @client.deployment_statuses(deployment.url).first.state
+  rescue Octokit::InvalidRepository
+    puts "ERROR: No repository name specified. Please set the GITHUB_TEST_REPOSITORY environment variable."
   end
 end


### PR DESCRIPTION
This is the error which I want to prevent when trying to create a deployment in `ansible-obs` with `bin/dotenv bin/ogd succeed --ref=something`:

> {"status":"error","reason":"POST https://api.github.com/repos/openSUSE/open-build-service/deployments: 409 - Conflict: Commit status checks failed for 528a66a6ee5e55b497f561f092e837fbc05abc07.\nError summary:\n  contexts: [{:context=>\"ci/circleci: checkout_code\", :state=>\"success\"}, {:context=>\"ci/circleci: backend_test\", :state=>\"success\"}, {:context=>\"ci/circleci: migrations_test\", :state=>\"success\"}, {:context=>\"ci/circleci: rspec\", :state=>\"success\"}, {:context=>\"ci/circleci: feature\", :state=>\"success\"}, {:context=>\"ci/circleci: minitest\", :state=>\"success\"}, {:context=>\"ci/circleci: coverage\", :state=>\"success\"}, {:context=>\"coverage/coveralls\", :state=>\"success\"}, {:context=>\"ci/circleci: spider\", :state=>\"success\"}, {:context=>\"codecov/project\", :state=>\"success\"}, {:context=>\"codecov/patch\", :state=>\"failure\"}]\n  resource: Deployment\n  field: required_contexts\n  code: invalid // See: https://docs.github.com/rest/reference/repos#create-a-deployment"}
