### PR TITLE
Lock the last commit, unlock the latest deployment

### DIFF
--- a/lib/obs_github_deployments/cli/commands/fail.rb
+++ b/lib/obs_github_deployments/cli/commands/fail.rb
@@ -4,12 +4,12 @@ module ObsGithubDeployments
   module CLI
     module Commands
       class Fail < ObsCommand
-        desc "Lock deployments for a specific GitHub repository"
+        desc "Create a succesful deployment"
 
         option :repository, default: ENV["GITHUB_REPOSITORY"],
                             desc: "GitHub repository name where deployments should get locked"
         option :ref, default: ENV["GITHUB_BRANCH"],
-                     desc: "GitHub branch name the locked deployment is referring to"
+                     desc: "Git ref (branch, tag, SHA1 etc.) that was deployed succesfully"
         option :token, default: ENV["GITHUB_TOKEN"],
                        desc: "GitHub authentication token used to authenticate against the API"
         option :reason, required: true, desc: "Why deployment failed?", default: "obs deployment failed"

--- a/lib/obs_github_deployments/cli/commands/lock.rb
+++ b/lib/obs_github_deployments/cli/commands/lock.rb
@@ -4,12 +4,10 @@ module ObsGithubDeployments
   module CLI
     module Commands
       class Lock < ObsCommand
-        desc "Lock deployments for a specific GitHub repository"
+        desc "Lock the deployment"
 
         option :repository, default: ENV["GITHUB_REPOSITORY"],
                             desc: "GitHub repository name where deployments should get locked"
-        option :ref, default: ENV["GITHUB_BRANCH"],
-                     desc: "GitHub branch name the locked deployment is referring to"
         option :token, default: ENV["GITHUB_TOKEN"],
                        desc: "GitHub authentication token used to authenticate against the API"
         option :reason, required: true, desc: "Explain reasoning behind locking the deployment process"
@@ -17,10 +15,13 @@ module ObsGithubDeployments
         def call(**options)
           check_options(options: options)
           ObsGithubDeployments::Deployment.new(repository: options[:repository],
-                                               access_token: options[:token],
-                                               ref: options[:ref]).lock(reason: options[:reason])
+                                               access_token: options[:token]).lock(reason: options[:reason])
 
           puts(status_response(status: "ok", reason: options[:reason]))
+        end
+
+        def required_keys
+          %i[repository token reason]
         end
       end
     end

--- a/lib/obs_github_deployments/cli/commands/obs_command.rb
+++ b/lib/obs_github_deployments/cli/commands/obs_command.rb
@@ -4,12 +4,10 @@ module ObsGithubDeployments
   module CLI
     module Commands
       class ObsCommand < Dry::CLI::Command
-        DEFAULT_ERROR = "You need to provide the respository name, branch and token"
-
         private
 
         def check_options(options:)
-          raise_error(DEFAULT_ERROR) unless (options.keys - required_keys).empty?
+          raise_error("You need to provide the #{required_keys.join(", ")} options") unless (required_keys - options.keys).empty?
         end
 
         def required_keys

--- a/lib/obs_github_deployments/cli/commands/succeed.rb
+++ b/lib/obs_github_deployments/cli/commands/succeed.rb
@@ -4,12 +4,12 @@ module ObsGithubDeployments
   module CLI
     module Commands
       class Succeed < ObsCommand
-        desc "Lock deployments for a specific GitHub repository"
+        desc "Create a succesful deployment"
 
         option :repository, default: ENV["GITHUB_REPOSITORY"],
                             desc: "GitHub repository name where deployments should get locked"
         option :ref, default: ENV["GITHUB_BRANCH"],
-                     desc: "GitHub branch name the locked deployment is referring to"
+                     desc: "Git ref (branch, tag, SHA1 etc.) that was deployed succesfully"
         option :token, default: ENV["GITHUB_TOKEN"],
                        desc: "GitHub authentication token used to authenticate against the API"
         option :reason, required: true, desc: "Why deployment succeed?", default: "obs deployed successfully"

--- a/lib/obs_github_deployments/cli/commands/unlock.rb
+++ b/lib/obs_github_deployments/cli/commands/unlock.rb
@@ -4,7 +4,7 @@ module ObsGithubDeployments
   module CLI
     module Commands
       class Unlock < ObsCommand
-        desc "Unlock deployments for a specific GitHub repository"
+        desc "Unlock the deployment"
 
         option :repository,
                default: ENV["GITHUB_REPOSITORY"],
@@ -14,16 +14,15 @@ module ObsGithubDeployments
                desc: "GitHub authentication token used to authenticate against the API"
 
         def call(**options)
-          raise_error("You need to provide a repository name") unless options[:repository]
-          raise_error("You need to provide a token in order to authenticate") unless options[:token]
+          check_options(options: options)
+          ObsGithubDeployments::Deployment.new(repository: options[:repository],
+                                               access_token: options[:token]).unlock
 
-          client(repository: options[:repository], token: options[:token]).unlock
-          puts status_response(status: "ok")
+          puts(status_response(status: "ok"))
         end
 
-        def client(repository:, token:)
-          ObsGithubDeployments::Deployment.new(repository: repository,
-                                               access_token: token)
+        def required_keys
+          %i[repository token]
         end
       end
     end

--- a/lib/obs_github_deployments/deployment.rb
+++ b/lib/obs_github_deployments/deployment.rb
@@ -43,6 +43,8 @@ module ObsGithubDeployments
       raise ObsGithubDeployments::Deployment::PendingError if deployment_status.blank?
       raise ObsGithubDeployments::Deployment::AlreadyLockedError if deployment_status.state == "queued"
 
+      @ref = lastest_commit # we just always use the latest ref to lock
+
       true if create_and_set_state(state: "queued", reason: reason)
     end
 
@@ -69,6 +71,10 @@ module ObsGithubDeployments
 
     def latest_status
       client.deployment_statuses(latest.url).first if latest
+    end
+
+    def lastest_commit
+      @client.commits(@repository, options = {per_page: 1})
     end
 
     def create


### PR DESCRIPTION
There is no reason for a ref specific lock. Either a repository is locked or not.

Also make it possible to overwrite required_keys in commands because some times not all options are neccessarry