### PR TITLE
Update octokit to v4.22

### DIFF
--- a/obs_github_deployments.gemspec
+++ b/obs_github_deployments.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 3"
   spec.add_dependency "activesupport"
   spec.add_dependency "dry-cli", "~> 0.6"
-  spec.add_dependency "octokit", "~> 4.20"
+  spec.add_dependency "octokit", "~> 4.22"
   spec.add_dependency "zeitwerk", "~> 2.4"
 
   # For more information and examples about making a new gem, checkout our


### PR DESCRIPTION
In order to remove this warning when running our tool [ansible-obs](https://github.com/openSUSE/ansible-obs):

```
changed: [obs -> localhost] => {
  "changed": true, 
  "cmd": "bin/dotenv bin/ogd check-lock",
  "delta": "0:00:02.643866", 
  "end": "2022-12-13 11:55:39.413344", 
  "rc": 0, 
  "start": "2022-12-13 11:55:36.769478", 
  "stderr": "WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
  While initializing your connection, use `#request(:authorization, ...)` instead.
  See https://lostisland.github.io/faraday/middleware/authentication for more usage info.", 
  "stderr_lines": [
    "WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.", 
    "While initializing your connection, use `#request(:authorization, ...)` instead.", 
    "See https://lostisland.github.io/faraday/middleware/authentication for more usage info."
  ], 
  "stdout": "{\"status\":\"unlocked\",\"reason\":\"\"}", 
  "stdout_lines": ["{\"status\":\"unlocked\",\"reason\":\"\"}"]
}
```

See https://github.com/octokit/octokit.rb/releases/tag/v4.22.0