### PR TITLE
Enforce defining dependencies in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ AllCops:
   TargetRubyVersion: 2.5
   NewCops: enable
 
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 Metrics/BlockLength:
   Exclude:
     - 'tasks/*'


### PR DESCRIPTION
The latest open PRs linters failed with:

```
Offenses:

obs_github_deployments.gemspec:33:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency "pry-byebug", "~> 3"
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  
[...]

3 files inspected, 8 offenses detected

```

Rubocop suggests defining them in Gemfile by default. But I propose to leave them in `obs_github_deployments.gemspec`  for now. 